### PR TITLE
Fix 3PAR driver handling of existing VLUNs

### DIFF
--- a/hp_3par_common.py
+++ b/hp_3par_common.py
@@ -152,10 +152,11 @@ class HP3PARCommon(object):
         2.0.22 - HP 3PAR drivers should not claim to have 'infinite' space
         2.0.23 - Increase the hostname size from 23 to 31  Bug #1371242
         2.88.24 - Removed usage of host name cache Bug #1398914
+        2.88.25 - Changed initialize_connection to use getHostVLUNs. #1475064
 
     """
 
-    VERSION = "2.88.24"
+    VERSION = "2.88.25"
 
     stats = {}
 
@@ -1800,6 +1801,30 @@ class HP3PARCommon(object):
         old_volume_settings = self.get_volume_settings_from_type(volume)
         return self._retype_from_old_to_new(volume, new_type,
                                             old_volume_settings, host)
+
+    def find_existing_vlun(self, volume, host):
+        """Finds an existing VLUN for a volume on a host.
+
+        Returns an existing VLUN's information. If no existing VLUN is found,
+        None is returned.
+
+        :param volume: A dictionary describing a volume.
+        :param host: A dictionary describing a host.
+        """
+        existing_vlun = None
+        try:
+            vol_name = self._get_3par_vol_name(volume['id'])
+            host_vluns = self.client.getHostVLUNs(host['name'])
+
+            # The first existing VLUN found will be returned.
+            for vlun in host_vluns:
+                if vlun['volumeName'] == vol_name:
+                    existing_vlun = vlun
+                    break
+        except hpexceptions.HTTPNotFound:
+            # ignore, no existing VLUNs were found
+            pass
+        return existing_vlun
 
     class TaskWaiter(object):
         """TaskWaiter waits for task to be not active and returns status."""

--- a/hp_3par_iscsi.py
+++ b/hp_3par_iscsi.py
@@ -75,10 +75,10 @@ class HP3PARISCSIDriver(cinder.volume.driver.ISCSIDriver):
                 and hp3parclient 3.1.0.
         2.0.6 - Fixing missing login/logout around attach/detach bug #1367429
         2.88.7 - Removed usage of host name cache Bug #1398914
-
+        2.88.8 - Changed initialize_connection to use getHostVLUNs. #1475064
     """
 
-    VERSION = "2.88.7"
+    VERSION = "2.88.8"
 
     def __init__(self, *args, **kwargs):
         super(HP3PARISCSIDriver, self).__init__(*args, **kwargs)
@@ -273,10 +273,25 @@ class HP3PARISCSIDriver(cinder.volume.driver.ISCSIDriver):
         try:
             # we have to make sure we have a host
             host, username, password = self._create_host(volume, connector)
-            least_used_nsp = self._get_least_used_nsp_for_host(host['name'])
+            least_used_nsp = None
+            # check if a VLUN already exists for this host
+            existing_vlun = self.common.find_existing_vlun(volume, host)
+            if existing_vlun:
+                # We override the nsp here on purpose to force the
+                # volume to be exported out the same IP as it already is.
+                # This happens during nova live-migration, we want to
+                # disable the picking of a different IP that we export
+                # the volume to, or nova complains.
+                least_used_nsp = self.common.build_nsp(existing_vlun['portPos'])
+            if not least_used_nsp:
+                least_used_nsp = self._get_least_used_nsp_for_host(host['name'])
 
-            # now that we have a host, create the VLUN
-            vlun = self.common.create_vlun(volume, host, least_used_nsp)
+            vlun = None
+            if existing_vlun is None:
+                # now that we have a host, create the VLUN
+                vlun = self.common.create_vlun(volume, host, least_used_nsp)
+            else:
+                vlun = existing_vlun
 
             if least_used_nsp is None:
                 msg = _("Least busy iSCSI port not found, "


### PR DESCRIPTION
Changes the 3PAR FC and iSCSI drivers to check for existing
VLUNs by taking into consideration both the volume and the host
when querying the backend.

Also pulled out some common code from the FC and iSCSI driver
to reduce duplicate code relating to the finding of existing
VLUNs.

This is a backport to stable/Juno of bug/1475064 and Kilo review;
https://review.openstack.org/#/c/227088/
