### PR TITLE
Fix 3PAR driver handling of existing VLUNs

### DIFF
--- a/hp_3par_common.py
+++ b/hp_3par_common.py
@@ -152,10 +152,11 @@ class HP3PARCommon(object):
         2.0.22 - HP 3PAR drivers should not claim to have 'infinite' space
         2.0.23 - Increase the hostname size from 23 to 31  Bug #1371242
         2.88.24 - Removed usage of host name cache Bug #1398914
+        2.88.25 - Changed initialize_connection to use getHostVLUNs. #1475064
 
     """
 
-    VERSION = "2.88.24"
+    VERSION = "2.88.25"
 
     stats = {}
 
@@ -1800,6 +1801,30 @@ class HP3PARCommon(object):
         old_volume_settings = self.get_volume_settings_from_type(volume)
         return self._retype_from_old_to_new(volume, new_type,
                                             old_volume_settings, host)
+
+    def find_existing_vlun(self, volume, host):
+        """Finds an existing VLUN for a volume on a host.
+
+        Returns an existing VLUN's information. If no existing VLUN is found,
+        None is returned.
+
+        :param volume: A dictionary describing a volume.
+        :param host: A dictionary describing a host.
+        """
+        existing_vlun = None
+        try:
+            vol_name = self._get_3par_vol_name(volume['id'])
+            host_vluns = self.client.getHostVLUNs(host['name'])
+
+            # The first existing VLUN found will be returned.
+            for vlun in host_vluns:
+                if vlun['volumeName'] == vol_name:
+                    existing_vlun = vlun
+                    break
+        except hpexceptions.HTTPNotFound:
+            # ignore, no existing VLUNs were found
+            pass
+        return existing_vlun
 
     class TaskWaiter(object):
         """TaskWaiter waits for task to be not active and returns status."""

--- a/hp_3par_fc.py
+++ b/hp_3par_fc.py
@@ -70,10 +70,11 @@ class HP3PARFCDriver(cinder.volume.driver.FibreChannelDriver):
                 is present.  bug #1360001
         2.0.8 - Fixing missing login/logout around attach/detach bug #1367429
         2.88.9 - Removed usage of host name cache Bug #1398914
+        2.88.10 - Changed initialize_connection to use getHostVLUNs. #1475064
 
     """
 
-    VERSION = "2.88.9"
+    VERSION = "2.88.10"
 
     def __init__(self, *args, **kwargs):
         super(HP3PARFCDriver, self).__init__(*args, **kwargs)
@@ -218,17 +219,24 @@ class HP3PARFCDriver(cinder.volume.driver.FibreChannelDriver):
             target_wwns, init_targ_map, numPaths = \
                 self._build_initiator_target_map(connector)
 
+            # check if a VLUN already exists for this host
+            existing_vlun = self.common.find_existing_vlun(volume, host)
+            vlun = None
+            if existing_vlun is None:
             # now that we have a host, create the VLUN
-            if self.lookup_service is not None and numPaths == 1:
-                nsp = None
-                active_fc_port_list = self.common.get_active_fc_target_ports()
-                for port in active_fc_port_list:
-                    if port['portWWN'].lower() == target_wwns[0].lower():
-                        nsp = port['nsp']
-                        break
-                vlun = self.common.create_vlun(volume, host, nsp)
+                if self.lookup_service is not None and numPaths == 1:
+                    nsp = None
+                    active_fc_port_list = \
+                        self.common.get_active_fc_target_ports()
+                    for port in active_fc_port_list:
+                        if port['portWWN'].lower() == target_wwns[0].lower():
+                            nsp = port['nsp']
+                            break
+                    vlun = self.common.create_vlun(volume, host, nsp)
+                else:
+                    vlun = self.common.create_vlun(volume, host)
             else:
-                vlun = self.common.create_vlun(volume, host)
+                vlun = existing_vlun
 
             info = {'driver_volume_type': 'fibre_channel',
                     'data': {'target_lun': vlun['lun'],

--- a/hp_3par_iscsi.py
+++ b/hp_3par_iscsi.py
@@ -75,10 +75,10 @@ class HP3PARISCSIDriver(cinder.volume.driver.ISCSIDriver):
                 and hp3parclient 3.1.0.
         2.0.6 - Fixing missing login/logout around attach/detach bug #1367429
         2.88.7 - Removed usage of host name cache Bug #1398914
-
+        2.88.8 - Changed initialize_connection to use getHostVLUNs. #1475064
     """
 
-    VERSION = "2.88.7"
+    VERSION = "2.88.8"
 
     def __init__(self, *args, **kwargs):
         super(HP3PARISCSIDriver, self).__init__(*args, **kwargs)
@@ -273,10 +273,27 @@ class HP3PARISCSIDriver(cinder.volume.driver.ISCSIDriver):
         try:
             # we have to make sure we have a host
             host, username, password = self._create_host(volume, connector)
-            least_used_nsp = self._get_least_used_nsp_for_host(host['name'])
+            least_used_nsp = None
+            # check if a VLUN already exists for this host
+            existing_vlun = self.common.find_existing_vlun(volume, host)
+            if existing_vlun:
+                # We override the nsp here on purpose to force the
+                # volume to be exported out the same IP as it already is.
+                # This happens during nova live-migration, we want to
+                # disable the picking of a different IP that we export
+                # the volume to, or nova complains.
+                least_used_nsp = \
+                    self.common.build_nsp(existing_vlun['portPos'])
+            if not least_used_nsp:
+                least_used_nsp = \
+                    self._get_least_used_nsp_for_host(host['name'])
 
-            # now that we have a host, create the VLUN
-            vlun = self.common.create_vlun(volume, host, least_used_nsp)
+            vlun = None
+            if existing_vlun is None:
+                # now that we have a host, create the VLUN
+                vlun = self.common.create_vlun(volume, host, least_used_nsp)
+            else:
+                vlun = existing_vlun
 
             if least_used_nsp is None:
                 msg = _("Least busy iSCSI port not found, "

--- a/test_hp3par.py
+++ b/test_hp3par.py
@@ -2014,10 +2014,12 @@ class TestHP3PARFCDriver(HP3PARBaseDriver, test.TestCase):
                              'vendor': None,
                              'wwn': self.wwn[1]}]}]
         mock_client.findHost.return_value = self.FAKE_HOST
-        mock_client.getHostVLUNs.return_value = [
-            {'active': True,
-             'volumeName': self.VOLUME_3PAR_NAME,
-             'lun': 90, 'type': 0}]
+        mock_client.getHostVLUNs.side_effect = [
+            hpexceptions.HTTPNotFound('fake'),
+            [{'active': True,
+              'volumeName': self.VOLUME_3PAR_NAME,
+              'lun': 90, 'type': 0}]]
+
         location = ("%(volume_name)s,%(lun_id)s,%(host)s,%(nsp)s" %
                     {'volume_name': self.VOLUME_3PAR_NAME,
                      'lun_id': 90,
@@ -2035,6 +2037,7 @@ class TestHP3PARFCDriver(HP3PARBaseDriver, test.TestCase):
             mock.ANY,
             mock.call.getHost(self.FAKE_HOST),
             mock.call.getPorts(),
+            mock.call.getHostVLUNs(self.FAKE_HOST),
             mock.call.createVLUN(
                 self.VOLUME_3PAR_NAME,
                 auto=True,
@@ -2075,10 +2078,12 @@ class TestHP3PARFCDriver(HP3PARBaseDriver, test.TestCase):
                              'vendor': None,
                              'wwn': self.wwn[0]}]}]
         mock_client.findHost.return_value = self.FAKE_HOST
-        mock_client.getHostVLUNs.return_value = [
-            {'active': True,
-             'volumeName': self.VOLUME_3PAR_NAME,
-             'lun': 90, 'type': 0}]
+        mock_client.getHostVLUNs.side_effect = [
+            hpexceptions.HTTPNotFound('fake'),
+            [{'active': True,
+              'volumeName': self.VOLUME_3PAR_NAME,
+              'lun': 90, 'type': 0}]]
+
         location = ("%(volume_name)s,%(lun_id)s,%(host)s,%(nsp)s" %
                     {'volume_name': self.VOLUME_3PAR_NAME,
                      'lun_id': 90,
@@ -2112,6 +2117,7 @@ class TestHP3PARFCDriver(HP3PARBaseDriver, test.TestCase):
             mock.ANY,
             mock.call.getHost(self.FAKE_HOST),
             mock.call.getPorts(),
+            mock.call.getHostVLUNs(self.FAKE_HOST),
             mock.call.getPorts(),
             mock.call.createVLUN(
                 self.VOLUME_3PAR_NAME,
@@ -2548,10 +2554,14 @@ class TestHP3PARISCSIDriver(HP3PARBaseDriver, test.TestCase):
             hpexceptions.HTTPNotFound('fake'),
             {'name': self.FAKE_HOST}]
         mock_client.findHost.return_value = self.FAKE_HOST
-        mock_client.getHostVLUNs.return_value = [
-            {'active': True,
-             'volumeName': self.VOLUME_3PAR_NAME,
-             'lun': self.TARGET_LUN, 'type': 0}]
+        mock_client.getHostVLUNs.side_effect = [
+            [{'hostname': self.FAKE_HOST,
+              'volumeName': self.VOLUME_3PAR_NAME,
+              'lun': self.TARGET_LUN,
+              'portPos': {'node': 8, 'slot': 1, 'cardPort': 1}}],
+            [{'active': True,
+              'volumeName': self.VOLUME_3PAR_NAME,
+              'lun': self.TARGET_LUN, 'type': 0}]]
         location = ("%(volume_name)s,%(lun_id)s,%(host)s,%(nsp)s" %
                     {'volume_name': self.VOLUME_3PAR_NAME,
                      'lun_id': self.TARGET_LUN,
@@ -2568,11 +2578,6 @@ class TestHP3PARISCSIDriver(HP3PARBaseDriver, test.TestCase):
             mock.call.getHost(self.FAKE_HOST),
             mock.call.findHost(iqn='iqn.1993-08.org.debian:01:222'),
             mock.call.getHost(self.FAKE_HOST),
-            mock.call.createVLUN(
-                self.VOLUME_3PAR_NAME,
-                auto=True,
-                hostname='fakehost',
-                portPos={'node': 8, 'slot': 1, 'cardPort': 1}),
             mock.call.getHostVLUNs(self.FAKE_HOST),
             mock.call.logout()]
 


### PR DESCRIPTION
Changes the 3PAR FC and iSCSI drivers to check for existing
VLUNs by taking into consideration both the volume and the host
when querying the backend.

Also pulled out some common code from the FC and iSCSI driver
to reduce duplicate code relating to the finding of existing
VLUNs.

This is a backport to stable/Juno of bug/1475064 and Kilo review;
https://review.openstack.org/#/c/227088/